### PR TITLE
Check if there are uploaded files before alerting

### DIFF
--- a/public/javascripts/submit_assignment.js
+++ b/public/javascripts/submit_assignment.js
@@ -123,7 +123,10 @@ define([
     });
 
     window.onbeforeunload = function() {
-      if($("#submit_assignment:visible").length > 0 && !submitting) {
+      var fileElements = $(this).find('input[type=file]:visible').filter(function() {
+          return $(this).val() !== '';
+        });
+      if($("#submit_assignment:visible").length > 0 && !submitting && fileElements.length !== 0) {
         return I18n.t('messages.not_submitted_yet', "You haven't finished submitting your assignment.  You still need to click \"Submit\" to finish turning it in.  Do you want to leave this page anyway?");
       }
     };


### PR DESCRIPTION
Harvard student here. I've been using Canvas for one of my courses, and I've found it really annoying that whenever I open up an assignment (just to look at the description, download the pdf spec, etc), I have to confirm via an alert box whenever I want to navigate away or close the tab. I've just added the basic additional check that the confirmation prompt will only come up if a file has actually been uploaded for this assignment.
